### PR TITLE
feat: homemanager shellconfig

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -73,10 +73,12 @@
 
   nixpkgs.config.allowUnfree = true;
 
+  users.defaultUserShell = pkgs.zsh;
+
   users.users.user = {
     isNormalUser = true;
     description = "user";
-    #shell = pkgs.zsh;
+    useDefaultShell = true;
     extraGroups = [ "networkmanager" "wheel" "video" "audio" ];
   #   packages = with pkgs; [
   #     home-manager
@@ -93,9 +95,9 @@
 
   services.getty.autologinUser = "user";
 
-  #programs.zsh = {
-  #  enable = true;
-  #};
+  programs.zsh = {
+   enable = true;
+  };
 
   programs.firefox.enable = true;
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -137,10 +137,10 @@
     firefox
     gvfs
     starship				# shell prompt
-	pyprland
-	libsForQt5.qt5ct
-	nitch
-	fd
+    pyprland
+    libsForQt5.qt5ct
+    nitch
+    fd
   ];
 
   # Some programs need SUID wrappers, can be configured further or are

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
               home-manager.useGlobalPkgs = true;
               # install packages to /etc/profiles/ rather than $HOME/.nix-profile
               home-manager.useUserPackages = true;
-              home-manager.users.user = import $HOME/.config/home-manager/home.nix;
+              #home-manager.users.user = import $HOME/.config/home-manager/home.nix;
             }
       ];
     };

--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,16 @@
       #extraSpecialArgs = {inherit inputs system;};
       specialArgs = {inherit inputs system;};
       modules = [
-	./configuration.nix
-	# ensures home-manager is enabled for all users on the system
-	home-manager.nixosModules.home-manager
+        ./configuration.nix
+          # ensures home-manager is enabled for all users on the system
+          home-manager.nixosModules.home-manager {
+              # use global packages configured via system-level nixpkgs rather
+              # than a private pkgs instance
+              home-manager.useGlobalPkgs = true;
+              # install packages to /etc/profiles/ rather than $HOME/.nix-profile
+              home-manager.useUserPackages = true;
+              home-manager.users.user = import $HOME/.config/home-manager/home.nix
+            }
       ];
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
               home-manager.useGlobalPkgs = true;
               # install packages to /etc/profiles/ rather than $HOME/.nix-profile
               home-manager.useUserPackages = true;
-              home-manager.users.user = import $HOME/.config/home-manager/home.nix
+              home-manager.users.user = import $HOME/.config/home-manager/home.nix;
             }
       ];
     };

--- a/home.nix
+++ b/home.nix
@@ -9,15 +9,17 @@
   home.packages = with pkgs; [
     neovim
     fzf
+    oh-my-zsh
     ripgrep
-    pay-respects        # command-not-found tool
+    pay-respects  # command-not-found tool
     signal-desktop
     btop
     tree
+    keychain
     zoxide
     mpv
-    zathura		# PDF reader
-    grimblast		# screencap
+    zathura # PDF reader
+    grimblast # screencap
     imagemagick
     ffmpeg
     ffmpegthumbnailer
@@ -97,7 +99,9 @@
   programs.zsh = {
     enable = true;
     autosuggestion.enable = true;
+    syntaxHighlighting.enable = true;
     enableCompletion = true;
+    autocd = true;
     shellAliases = {
       ls="ls --color=auto";
       la="ls -la";
@@ -106,6 +110,28 @@
       sbt="sbt -ivy $XDG_DATA_HOME/ivy2 -sbt-dir $XDG_DATA_HOME/sbt";
       mvn="mvn -gs $XDG_CONFIG_HOME/maven/settings.xml";
       nvidia-settings="nvidia-settings --config=$XDG_CONFIG_HOME/nvidia/settings";
+    };
+    dirHashes = {
+      dev = "$HOME/dev";
+      dl = "$HOME/tmp";
+    };
+    dotDir = ".config/zsh";
+    # extra commands to be added to .zshenv
+    envExtra = 
+      "export RUSTUP_HOME=${config.xdg.dataHome}/rustup\n
+       export CARGO_HOME=${config.xdg.dataHome}/cargo";
+    # extra commands to be added to .zshrc
+    initExtra =
+      "eval \"$(zoxide init zsh)\" > /dev/null 2>&1\n
+       eval \"$(keychain --absolute --dir $XDG_RUNTIME_DIR/keychain --eval --agents ssh ~/.ssh/github --quiet)\"";
+    oh-my-zsh = {
+      enable = true;
+      plugins = [
+        "git"
+        "sudo"
+        "fzf"
+      ];
+      theme = "bira";
     };
   };
 


### PR DESCRIPTION
Configure home-manager to handle most zsh settings. Current config includes most important ones from my old dotfiles repo, except a bunch of paths which will have to be configured on a per-case bases.